### PR TITLE
fix(login): 修复 VPN 模式下 iClass 登录失败

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "my_iclass",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "my_iclass",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "license": "MIT",
             "devDependencies": {
                 "concurrently": "^8.2.2",

--- a/server/src/config/constants.ts
+++ b/server/src/config/constants.ts
@@ -9,6 +9,7 @@ const DIRECT_BASE = "https://iclass.buaa.edu.cn:8347";
 export const ICLASS_URLS = {
     VPN: {
         SERVICE_HOME: VPN_BASE,
+        MY_CENTER: "https://d.buaa.edu.cn/https-8346/77726476706e69737468656265737421f9f44d9d342326526b0988e29d51367ba018/?type=jumpMyCenter",
         USER_LOGIN: `${VPN_BASE}/app/user/login.action`,
         COURSE_LIST: `${VPN_BASE}/app/choosecourse/get_myall_course.action`,
         SEMESTER_LIST: `${VPN_BASE}/app/course/get_base_school_year.action`,
@@ -18,6 +19,7 @@ export const ICLASS_URLS = {
     },
     DIRECT: {
         SERVICE_HOME: DIRECT_BASE,
+        MY_CENTER: "https://iclass.buaa.edu.cn:8346/?type=jumpMyCenter",
         USER_LOGIN: `${DIRECT_BASE}/app/user/login.action`,
         COURSE_LIST: `${DIRECT_BASE}/app/choosecourse/get_myall_course.action`,
         SEMESTER_LIST: `${DIRECT_BASE}/app/course/get_base_school_year.action`,
@@ -30,4 +32,3 @@ export const ICLASS_URLS = {
 
 // Apply a conservative negative correction for VPN time sync to avoid future timestamps.
 export const VPN_OFFSET_CORRECTION_MS = -1000;
-

--- a/server/src/core/IClassClient.ts
+++ b/server/src/core/IClassClient.ts
@@ -3,7 +3,7 @@ import { CookieJar } from 'tough-cookie';
 import { vpnLogin } from './authCore';
 import { CourseDetailItem, CourseItem, getCourseByDate as getCourseByDateCore, getCourses, getCoursesDetail, getCurrentSemester } from './courseCore';
 import { signNow as signNowOnline } from './signCore';
-import { fetchUserInfoFromApi } from './userCore';
+import { fetchUserInfoFromApi, resolveIclassLoginName } from './userCore';
 
 export interface IClassLoginInput {
     studentId: string;
@@ -44,7 +44,11 @@ export class IClassClient {
 
         if (this.useVpn) {
             await vpnLogin(this.client, vpnUsername, vpnPassword);
-            await this.fetchUserInfo(studentId);
+            const loginName = await resolveIclassLoginName(this.client, true);
+            if (!loginName) {
+                throw new Error('无法从 iClass 跳转解析 loginName');
+            }
+            await this.fetchUserInfo(loginName);
             return;
         }
 

--- a/server/src/core/userCore.ts
+++ b/server/src/core/userCore.ts
@@ -2,11 +2,65 @@ import type { Got } from 'got';
 import { ICLASS_URLS, VPN_OFFSET_CORRECTION_MS } from '../config/constants';
 import logger from '../utils/logger';
 
+const LOGIN_NAME_REDIRECT_LIMIT = 8;
+
 export interface UserInfoResult {
     userInfo: any;
     sessionId: string | null;
     serverTimeOffset: number; // 服务器偏移量（毫秒）
 }
+
+/**
+ * Follows the iClass MyCenter SSO redirect chain and extracts the transient loginName.
+ */
+export const resolveIclassLoginName = async (
+    client: Got,
+    useVpn: boolean
+): Promise<string | null> => {
+    const network = useVpn ? 'VPN' : 'DIRECT';
+    const noRedirectClient = client.extend({
+        followRedirect: false,
+        throwHttpErrors: false
+    });
+    let currentUrl: string = ICLASS_URLS[network].MY_CENTER;
+
+    for (let i = 0; i < LOGIN_NAME_REDIRECT_LIMIT; i += 1) {
+        const res: any = await noRedirectClient.get(currentUrl);
+        const finalUrl = res.url || currentUrl;
+
+        const loginName = extractLoginName(finalUrl)
+            || extractLoginName(String(res.headers.location || ''))
+            || extractLoginName(typeof res.body === 'string' ? res.body : '');
+        if (loginName) {
+            return loginName;
+        }
+
+        const location = String(res.headers.location || '');
+        if (res.statusCode < 300 || res.statusCode >= 400 || !location) {
+            return null;
+        }
+
+        currentUrl = new URL(location, finalUrl).toString();
+    }
+
+    return null;
+};
+
+/**
+ * Decodes loginName without treating literal plus signs as spaces.
+ */
+const extractLoginName = (value: string): string | null => {
+    const match = /[?&#]loginname=([^&#"'<>\s]+)/i.exec(value);
+    if (!match?.[1]) {
+        return null;
+    }
+
+    try {
+        return decodeURIComponent(match[1]);
+    } catch {
+        return match[1];
+    }
+};
 
 export const fetchUserInfoFromApi = async (
     client: Got,


### PR DESCRIPTION
- 新增 iClass MyCenter 入口地址，用于获取真实登录态中的 loginName
- WebVPN SSO 登录成功后，跟随 MyCenter 跳转链解析 loginName
- 调用 app/user/login.action 时改用 loginName，不再直接使用学号，避免 ERRCODE=106“用户不存在”
- 保持直连登录、课程列表和签到接口逻辑不变